### PR TITLE
Fix compilation warning.

### DIFF
--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -129,7 +129,9 @@ void version() {
   if (!(version_file = fopen("VERSION", "rb"))) {
     tty_solitaire_generic_error(errno, __FILE__, __LINE__);
   }
-  if (!fread(version_string, 1, 5, version_file));
+  if (!fread(version_string, 1, 5, version_file)) {
+    // TODO: handle this.
+  }
   version_string[5] = '\0';
   printf("%s\n", version_string);
   fclose(version_file);


### PR DESCRIPTION
`make` will give a warning unless there's either a block or a newline semi-colon following the `if` statement.

```
$ make
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/common.o src/common.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/frame.o src/frame.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/card.o src/card.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/stack.o src/stack.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/deck.o src/deck.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/cursor.o src/cursor.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/keyboard.o src/keyboard.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/gui.o src/gui.c
gcc -W -Wall -pedantic -ansi -std=c99 -g   -c -o src/game.o src/game.c
gcc -W -Wall -pedantic -ansi -std=c99 -g src/ttysolitaire.c -o ttysolitaire src/common.o src/frame.o src/card.o src/stack.o src/deck.o src/cursor.o src/keyboard.o src/gui.o src/game.o  -lncurses
src/ttysolitaire.c:132:50: warning: if statement has empty body [-Wempty-body]
  if (!fread(version_string, 1, 5, version_file));
                                                 ^
src/ttysolitaire.c:132:50: note: put the semicolon on a separate line to silence this warning
1 warning generated.
```